### PR TITLE
Upgrade actions: checkout and setup-java

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -4,8 +4,8 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           distribution: zulu
           java-version: 11

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -4,8 +4,8 @@ jobs:
   publish-api-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           distribution: zulu
           java-version: 11

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,8 +7,8 @@ jobs:
   publish-artifacts:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           distribution: zulu
           java-version: 11


### PR DESCRIPTION
see https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/